### PR TITLE
Optimize asHexString method

### DIFF
--- a/src/main/java/com/github/charithe/flake4j/Flake4J.java
+++ b/src/main/java/com/github/charithe/flake4j/Flake4J.java
@@ -33,6 +33,7 @@ public class Flake4J {
     private static final int MAX_SEQ = 0xFFFF;
     private static final int ID_SIZE_BYTES = 16;
     private static final int NODE_ID_BYTES = 6;
+    private static final String HEX_VALUES = "0123456789abcdef";
     private final Lock lock = new ReentrantLock(true);
     private final byte[] nodeId;
     private final Clock clock;
@@ -114,9 +115,9 @@ public class Flake4J {
     }
 
     public static String asHexString(byte[] id) {
-        StringBuilder sb = new StringBuilder();
-        for (byte component : id) {
-            sb.append(String.format("%02x", component));
+        final StringBuilder sb = new StringBuilder(2 * id.length);
+        for (final byte b : id) {
+            sb.append(HEX_VALUES.charAt((b & 0xF0) >> 4)).append(HEX_VALUES.charAt((b & 0x0F)));
         }
         return sb.toString();
     }


### PR DESCRIPTION
The method asHexString has been rewrite. `String.format` has been removed and the method was now around 60 times faster.


Benchmarked with a 100K iteration with the following code:
```java
for (int j = 0; j < 3; ++j) {
    startTime = System.currentTimeMillis();
    for (int i = 0; i < 100000; ++i) {
        asHexString_OLD(data);
    }
    endTime = System.currentTimeMillis();
    LOG.info("asHexString_OLD -> {}ms", endTime - startTime);
}
for (int j = 0; j < 3; ++j) {
    startTime = System.currentTimeMillis();
    for (int i = 0; i < 100000; ++i) {
        asHexString_NEW(data);
    }
    endTime = System.currentTimeMillis();
    LOG.info("asHexString_NEW -> {}ms", endTime - startTime);
}
```

```console
[2017-04-22 21:04:42] INFO - MainEntry - asHexString_OLD -> 3130ms
[2017-04-22 21:04:44] INFO - MainEntry - asHexString_OLD -> 2615ms
[2017-04-22 21:04:47] INFO - MainEntry - asHexString_OLD -> 2573ms
[2017-04-22 21:04:47] INFO - MainEntry - asHexString_NEW -> 40ms
[2017-04-22 21:04:47] INFO - MainEntry - asHexString_NEW -> 24ms
[2017-04-22 21:04:47] INFO - MainEntry - asHexString_NEW -> 22ms
```