### PR TITLE
Optimize asComponentString method

### DIFF
--- a/src/main/java/com/github/charithe/flake4j/Flake4J.java
+++ b/src/main/java/com/github/charithe/flake4j/Flake4J.java
@@ -123,10 +123,8 @@ public class Flake4J {
 
     public static String asComponentString(byte[] id) {
         ByteBuffer buffer = ByteBuffer.wrap(id);
-        long ts = buffer.getLong();
         byte[] node = new byte[NODE_ID_BYTES];
         buffer.get(node);
-        int seq = buffer.getShort();
-        return String.format("%d-%d-%d", ts, new BigInteger(node).longValue(), seq);
+        return buffer.getLong() + "-" + new BigInteger(node).longValue() + "-" + buffer.getShort();
     }
 }


### PR DESCRIPTION
The method asComponentString has been rewrite. String.format has been removed and the method was now around 10 times faster.

Benchmarked with a 100K iteration with the following code:
```java
for (int j = 0; j < 3; ++j) {
    startTime = System.currentTimeMillis();
    for (int i = 0; i < 100000; ++i) {
        asComponentString_OLD(data);
    }
    endTime = System.currentTimeMillis();
    LOG.info("asComponentString_OLD -> {}ms", endTime - startTime);
}
for (int j = 0; j < 3; ++j) {
    startTime = System.currentTimeMillis();
    for (int i = 0; i < 100000; ++i) {
        asComponentString_NEW(data);
    }
    endTime = System.currentTimeMillis();
    LOG.info("asComponentString_NEW -> {}ms", endTime - startTime);
}
```

```console
[2017-04-22 21:04:42] INFO - MainEntry - asComponentString_OLD -> 508ms
[2017-04-22 21:04:44] INFO - MainEntry - asComponentString_OLD -> 220ms
[2017-04-22 21:04:47] INFO - MainEntry - asComponentString_OLD -> 220ms
[2017-04-22 21:04:47] INFO - MainEntry - asComponentString_NEW -> 57ms
[2017-04-22 21:04:47] INFO - MainEntry - asComponentString_NEW -> 29ms
[2017-04-22 21:04:47] INFO - MainEntry - asComponentString_NEW -> 27ms
```